### PR TITLE
Fix warning by adding key attribute to each graph thumbnail in sidebar

### DIFF
--- a/docs/docs/design.mdx
+++ b/docs/docs/design.mdx
@@ -32,6 +32,20 @@ response flow through the system.
 
 ![Error loading high-level-design.png](./img/high-level-design.png)
 
+Dependency Injection
+--------------------
+
+In order to optimize our developer's experience, Nexus Graph runs against very different configurations in
+Dev/Test/Prod environments. This puts some challenges on the design of system. Dependency injection is one of them.
+For example, in dev mode, we want our UI engineer to go completely free by decoupling backend developments. We do that
+by running in-memory backend services. This means for those services, we need to automatically wire up different
+implementations in Dev and Prod environment.
+
+To address that, we use [Inversify] to dynamically load 2 of our components:
+
+1. AI Entity Extraction Service
+2. Graph API Webservice
+
 Redux Module
 ------------
 
@@ -477,6 +491,8 @@ The Graph API server should support the following Operations with specified Grap
 [Graph]: https://nexusgraph.qubitpi.org/api/interfaces/nexusgraph_redux.Graph.html
 [Graph Link]: https://nexusgraph.qubitpi.org/api/interfaces/nexusgraph_redux.Link.html
 [Graph Node]: https://nexusgraph.qubitpi.org/api/interfaces/nexusgraph_redux.Node.html
+
+[Inversify]:https://inversify.qubitpi.org/
 
 [Redux Action Creators]: https://redux.qubitpi.org/style-guide/#use-action-creators
 [Redux Selector Functions]: https://redux.qubitpi.org/usage/deriving-data-selectors/#basic-selector-concepts

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -161,6 +161,18 @@ yarn start
 which Runs the app in the development mode. The page will reload if you make edits. You will also see any lint errors in
 the console.
 
+:::info
+
+Note that Logto Login is disabled by default in dev mode. To turn it on, make sure to put
+
+```text
+SKIP_SIGN_IN=false
+```
+
+in `.env`
+
+:::
+
 Writing TypeDoc
 ---------------
 

--- a/packages/nexusgraph-app/src/component/sidebar/SideBar.tsx
+++ b/packages/nexusgraph-app/src/component/sidebar/SideBar.tsx
@@ -28,6 +28,7 @@ export default function SideBar(props: SideBarProps): JSX.Element {
       <NewGraphButton />
       {props.graphList.map((metaData) => (
         <StyledGraphListItem
+          key={metaData.id}
           data-testid={`graphListItem-${metaData.id}`}
           onClick={() => props.onClick(metaData.id)}
           displayedItem={metaData.id == graphId}


### PR DESCRIPTION
- [Why](https://stackoverflow.com/questions/28329382/understanding-unique-keys-for-array-children-in-react-js)
- [How](https://stackoverflow.com/questions/69569486/should-have-unique-key-prop-when-i-have-unique-keys-for-all-components-inside)

The warning shows up as:

![page](https://github.com/QubitPi/nexusgraph/assets/16126939/d30b9658-b720-4f84-9b72-46c2de021e87)
